### PR TITLE
Make lists conform to the standard style

### DIFF
--- a/generator/source/_sass/base/_global.scss
+++ b/generator/source/_sass/base/_global.scss
@@ -109,7 +109,8 @@ p, ol, ul, dl, .math-display {
   width: 100%;
 }
 ol, ul {
-  list-style-position: inside;
+  list-style-position: outside;
+  padding-left: 1.2em;
 }
 hr {
   border: 0;


### PR DESCRIPTION
By default, list-lines and wrapped-list-lines are indented equally.
The theme in use eliminates all padding, including the indentation
of lists. This applies default padding and settings to lists. BIP-379

Signed-off-by: Sutrannu <bbetts@bitwise.io>