### PR TITLE
Reformat, rewrite, and expand FAQ for grid-website

### DIFF
--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -12,26 +12,35 @@ feat_img_size: small
 Hyperledger Grid FAQ
 ====================
 
-Frequently Asked Questions (FAQ) for Hyperledger Grid.
+General questions
+-----------------
 
-Frequently-asked Questions
---------------------------
+- `What is Hyperledger Grid? </faq/grid/#what-is-hyperledger-grid>`__
 
-- `Grid in General`_
+- `What is the status of this project?
+  </faq/grid/what-is-the-status-of-this-project>`__
 
-Contributing
-------------
+- `Where is the source code? </faq/grid/#where-is-the-source-code>`__
 
-This FAQ is licensed under Creative Commons Attribution 4.0 International
-License. You may obtain a copy of the license at:
+- `Where is the documentation? </faq/grid/#where-is-the-documentation>`__
+
+- `How can I ask a question about Hyperledger Grid?
+  </faq/grid/#how-can-i-ask-a-question-about-hyperledger-grid>`__
+
+- `How can I contribute to this project?
+  </faq/grid/#how-can-i-contribute-to-this-project>`__
+
+Contributing to this FAQ
+------------------------
+
+The Hyperledger Grid FAQ is licensed under Creative Commons Attribution 4.0
+International License. You may obtain a copy of the license at
 http://creativecommons.org/licenses/by/4.0/.
 
-We accept contributions via GitHub_ pull requests. Each commit must include a
-``Signed-off-by:`` in the commit message (``git commit -s``).
-This sign-off means you agree the commit satisfies the
-`Developer Certificate of Origin (DCO)`_.]
+We accept contributions to this FAQ in the form of GitHub_ pull requests.
+Each commit must include a "Signed-off-by" line in the commit message (as
+produced by ``git commit -s``). This sign-off means you agree that the commit
+satisfies the `Developer Certificate of Origin (DCO)`_.
 
-.. _Grid in General: grid
 .. _GitHub: https://github.com/hyperledger/grid-website
 .. _Developer Certificate of Origin (DCO): https://developercertificate.org/
-.. _NEXT: /faq/grid/

--- a/generator/source/faq/grid.rst
+++ b/generator/source/faq/grid.rst
@@ -2,46 +2,130 @@
 layout: page
 hide: true
 tags: [faq]
-title: Grid FAQ - Hyperledger Grid in General
+title: General FAQ
 permalink: /faq/grid/
 # Copyright (c) 2018-2019, Bitwise IO, Inc.
 # Copyright (c) 2018, Intel Corporation.
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-Grid FAQ: Hyperledger Grid in General
-=====================================
-.. class:: mininav
 
-PREVIOUS_ FAQ_
+General Hyperledger Grid FAQ
+============================
 
 .. contents::
 
+.. _faq-what-is-hyperledger-grid:
 
-What is Grid?
--------------
+What is Hyperledger Grid?
+-------------------------
 
-Hyperledger Grid is a project for building supply chain solutions. It includes
-a set of libraries, data models, and SDKs to accelerate development for supply
-chain smart contracts and client interfaces.
+Hyperledger Grid is a platform for building supply chain solutions that include
+distributed ledger components. This project's goal is to speed up the development
+of modular blockchain-based solutions for cross-industry supply chain problems.
 
-What are some useful Grid links?
---------------------------------
+Hyperledger Grid provides a set of libraries, data models, and SDKs that can be
+used to develop supply chain smart contracts and client interfaces.
 
-GitHub repository for Grid
-    https://github.com/hyperledger/grid
-Grid documentation:
-    https://grid.hyperledger.org/docs/
-Grid chat main channel
-    https://chat.hyperledger.org/channel/grid
-Grid mailing list (not as popular as the chat channel above)
-    https://lists.hyperledger.org/g/grid
-Grid FAQ
-    https://grid.hyperledger.org/faq/
+For more information:
 
-.. class:: mininav
+* `About Hyperledger Grid </about>`__
 
-PREVIOUS_ FAQ_
+* `Announcing Hyperledger Grid
+  <https://www.hyperledger.org/blog/2019/01/22/announcing-hyperledger-grid-a-new-project-to-help-build-and-deliver-supply-chain-solutions>`__
+  (Hyperledger blog)
 
-.. _PREVIOUS: /faq/
-.. _FAQ: /faq/
+* `Hyperledger Grid documentation </docs>`__
+
+.. _faq-what-is-the-status-of-this-project:
+
+What is the status of this project?
+-----------------------------------
+
+Hyperledger Grid is currently in the `incubation
+<https://wiki.hyperledger.org/display/HYP/Project+Lifecycle#ProjectLifecycle-incubation>`__
+stage of the Hyperledger product lifecycle. The `Hyperledger Grid proposal
+<https://docs.google.com/document/d/1b6ES0bKUK30E2iZizy3vjVEhPn7IvsW5buDo7nFXBE0/>`__
+was accepted in December, 2018.
+
+.. _faq-where-is-the-source-code:
+
+Where is the source code?
+-------------------------
+
+Hyperledger Grid is an open source project. The source code is in several GitHub
+repositories:
+
+* `hyperledger/grid <https://github.com/hyperledger/grid>`__: Core components
+  such as supply-chain-centric data types and reference implementations of
+  smart contracts
+
+* `hyperledger/grid-contrib <https://github.com/hyperledger/grid-contrib>`__:
+  Contributed code that is not yet in the core grid repository, as well as
+  example domain models and reference implementations for smart contracts
+  (also called "transaction families")
+
+* `hyperledger/grid-rfcs <https://github.com/hyperledger/grid-rfcs>`__:
+  RFCs (requests for comments) for proposed and approved changes to
+  Hyperledger Grid
+
+.. _faq-where-is-the-documentation:
+
+Where is the documentation?
+---------------------------
+
+See `Docs </docs>`__ for all current Hyperledger Grid documentation.
+
+Note that this project is in `incubation
+<https://wiki.hyperledger.org/display/HYP/Project+Lifecycle#ProjectLifecycle-incubation>`__
+(has not been released). The documentation is preliminary and changes often.
+
+.. _faq-how-can-i-ask-a-question-about-hyperledger-grid:
+
+How can I ask a question about Hyperledger Grid?
+------------------------------------------------
+
+Hyperledger hosts a Grid chat channel and mailing list. These tools require a
+free `Linux Foundation ID <https://identity.linuxfoundation.org/>`__.
+
+* `#grid chat channel <https://chat.hyperledger.org/channel/grid>`__
+
+* `Hyperledger Grid mailing list <https://lists.hyperledger.org/g/grid>`__
+
+See `Joining the Discussion </community/join_the_discussion>`__ for more
+information.
+
+.. _faq-how-can-i-contribute-to-this-project:
+
+How can I contribute to this project?
+-------------------------------------
+
+We welcome contributors, both organizations and individuals, to help shape
+project direction, contribute ideas, provide use cases, and work on specific
+tools and examples.
+
+* Join us in the `Grid chat or mailing list </community/join_the_discussion/>`__
+  to discuss ideas, propose new features, or just ask questions.
+
+* Attend the Hyperledger Grid Contributor meetings on Zoom. For meeting
+  annnouncements, see the `Hyperledger meeting calendar
+  <https://wiki.hyperledger.org/display/HYP/Calendar+of+Public+Meetings>`__
+  or `Grid mailing list <https://lists.hyperledger.org/g/grid>`__.
+  Lurkers are welcome! Feel free to just listen.
+
+* For code contributions, please see our
+  `contributing guide </community/contributing>`__.
+
+* This project requires an RFC (request-for-change proposal) for any significant
+  change or new feature. For more information, see
+  `grid-rfcs/README <https://github.com/hyperledger/grid-rfcs/blob/master/README.md>`__.
+
+* We follow the Hyperledger Code of Conduct. Please see our `code of conduct
+  page </community/code_of_conduct>`__.
+
+----------
+
+This FAQ is licensed under Creative Commons Attribution 4.0 International
+License. You may obtain a copy of the license at
+http://creativecommons.org/licenses/by/4.0/.
+


### PR DESCRIPTION
- Fix FAQ presentation, organization, and usability
  - Add direct links to questions from main page
  - Retitle and reorganize the general page
  - Remove mini-nav buttons:
    (a) There's only one FAQ page right now
    (b) "Next" and "Previous" are not meaningful in a FAQ
    Will handle nav differently if the FAQ ever gets too large.

- Rewrite "What is Hyperledger Grid" to match new overview on home page (in a separate PR)

- Add more FAQ questions/answers

- Rewrite "Contributing to this FAQ" for clarity

Signed-off-by: Anne Chenette <chenette@bitwise.io>