### PR TITLE
Propose new maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @RyanLassigBanks @vaporos
+*       @agunde406 @chenette @davececchi @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rberg2 @rbuysse @RyanLassigBanks @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@
 | Dave Cecchi | davececchi | cecchi |
 | James Mitchell | jsmitchell | jsmitchell |
 | Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
 | Ryan Banks | RyanLassigBanks | RyanBanks |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |


### PR DESCRIPTION
Propose that Richard Berg be added as a maintainer.

As described in the Grid Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.